### PR TITLE
Add minimal unit test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ clean:
 	rm -f src/webfrontend/*.coffee.js
 	rm -f build-stamp-l10n
 	rm -rf build/
+	rm -rf test/*.coffee.js
 
 build-stamp-l10n: $(L10N_FILES) $(CULTURES_CSV)
 	mkdir -p build/webfrontend/l10n
@@ -28,6 +29,10 @@ build-stamp-l10n: $(L10N_FILES) $(CULTURES_CSV)
 ${JS_FILE}: src/webfrontend/CustomDataTypeGND.coffee.js
 	mkdir -p build/webfrontend
 	cat $^ > $@
+
+test: ${JS_FILE} test/mock.coffee.js test/smoke.coffee.js
+	cat test/mock.coffee.js ${JS_FILE} test/smoke.coffee.js > test/tmp.coffee.js
+	node test/tmp.coffee.js
 
 %.coffee.js: %.coffee
 	coffee -b -p --compile "$^" > "$@" || ( rm -f "$@" ; false )

--- a/test/mock.coffee
+++ b/test/mock.coffee
@@ -1,0 +1,8 @@
+class Session
+
+class Menu
+
+class Pane
+
+class CustomDataType
+    @register: (datatype) -> 

--- a/test/smoke.coffee
+++ b/test/smoke.coffee
@@ -1,0 +1,6 @@
+# create a new instance
+gndtype = new CustomDataTypeGND
+
+# call a method and hope it does not die
+gndtype.getCustomDataTypeName()
+


### PR DESCRIPTION
`make test` will compile coffeescript and create an instance of the custom datatype with nodejs. More elaborated unit tests require a testing framework such as mocha.
